### PR TITLE
fix(melanoma): Updated model url

### DIFF
--- a/examples/melanoma.js
+++ b/examples/melanoma.js
@@ -45,7 +45,7 @@ async function run() {
 async function predict(file) {
   // Load model
   const model = await tf.loadLayersModel(
-    "https://raw.githubusercontent.com/gaiborjosue/melanoma_detection/website/vggMeshOut/model.json"
+    "https://raw.githubusercontent.com/mpsych/melanoma/main/weights/model.json"
   );
 
   // Get the image


### PR DESCRIPTION
This PR is a minor change since it only updates the Melanoma Predictor Boostlet to the same URL/model.json as the melanoma website.

This ensures consistency within environments.